### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.new
     @items = Item.all.order("created_at DESC")
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    # @items = Item.new
-    # @items = Item.all
+    @items = Item.new
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,11 +127,11 @@
     <ul class='item-lists'>
 
       
-      <%# <% @items.each do |item| %> 
+      <% @items.each do |item| %> 
         <li class='list'>
           <%= link_to "#" do %>
           <div class='item-img-content'>
-            <%# <%= image_tag(item.image, class: "item-img") %> 
+            <%= image_tag(item.image, class: "item-img") %> 
 
             <%# 商品が売れていればsold outを表示しましょう %>
             <div class='sold-out'>
@@ -142,10 +142,10 @@
           </div>
           <div class='item-info'>
             <h3 class='item-name'>
-              <%# <%= item.name %>
+              <%= item.name %>
             </h3>
             <div class='item-price'>
-              <%# <span><%= item.price円<br><%= '配送料負担' %><%#</span> %>
+              <span><%= item.price %>円<br><%= '配送料負担' %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
@@ -154,12 +154,10 @@
           </div>
           <% end %>
         </li>
-      <%# <% end %>
+      <% end %>
       
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <%# <% if @items.count == 0 %>
+      <% if @items.count == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -177,9 +175,8 @@
         </div>
         <% end %>
       </li>
-      <%# <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
+      
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -145,7 +145,7 @@
               <%= item.name %>
             </h3>
             <div class='item-price'>
-              <span><%= item.price %>円<br><%= '配送料負担' %></span>
+              <span><%= item.price %>円<br><%= item.shipping_charge_id.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -145,7 +145,7 @@
               <%= item.name %>
             </h3>
             <div class='item-price'>
-              <span><%= item.price %>円<br><%= item.shipping_charge_id.name %></span>
+              <span><%= item.price %>円<br><%= item.shipping_charge.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
出品された商品をトップページに一覧で表示させるため。

* Gyazo GIF
ログアウト状態でも商品の一覧をみることができること：https://gyazo.com/3a9bb858ec3374f6ee428ee05f220d8c
ログイン状態で商品の一覧が見れること：https://gyazo.com/82abaf2263349a2e1d97ccaff1482151
上から新しい順に並び、画像、価格、商品名が表示されていること：https://gyazo.com/af13bda66351d5b556fced2938e662b9


レビューをして頂きたく、お願い申し上げます。

