### PR TITLE
エラー時のプレビュー画像削除

### DIFF
--- a/app/assets/stylesheets/items/new.css
+++ b/app/assets/stylesheets/items/new.css
@@ -74,8 +74,8 @@
 
 /* 出品画像 */
 .img-upload {
-  display: flex;
-  justify-content: space-between;
+  /* display: flex; */
+  /* justify-content: space-between; */
   flex-wrap: wrap;
   padding: 2vh 0;
 }
@@ -88,6 +88,9 @@
 .click-upload>p {
   margin-bottom: 15px;
 }
+/* .item-box_img {
+  width: 120px;
+} */
 
 /* /出品画像 */
 

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,8 +1,9 @@
-if (document.URL.match( /new/ ) || document.URL.match( /edit/ )) {
+if (document.URL.match( /new/ ) || document.URL.match( /edit/ ) || document.URL.match( /items/ )) {
   document.addEventListener('DOMContentLoaded', function() {
     const ImageList = document.getElementById('image-list')
 
     const createImageHTML = (blob) => {
+
       const imageElement = document.createElement('div')
       imageElement.setAttribute('class', "image-element")
       let imageElementNum = document.querySelectorAll('.image-element').length
@@ -31,10 +32,17 @@ if (document.URL.match( /new/ ) || document.URL.match( /edit/ )) {
     document.getElementById('item-image').addEventListener('change', (e) => {
       let file = e.target.files[0];
       let blob = window.URL.createObjectURL(file);
-      
+
       createImageHTML(blob)
 
     });
+
+    document.getElementsByClassName('item-box-img')[0].remove();
+    document.getElementsByClassName('item-box-img')[0].remove();
+    document.getElementsByClassName('item-box-img')[0].remove();
+    document.getElementsByClassName('item-box-img')[0].remove();
+
+
   });
 }
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -22,6 +22,7 @@ app/assets/stylesheets/items/new.css %>
       <div class="click-upload">
         <p>
           クリックしてファイルをアップロード
+          (最大3枚までとしてください) 
         </p>
         <%= f.file_field :images, name: 'item[images][]', id:"item-image" %>
       </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -20,13 +20,15 @@
       <div class="click-upload">
         <p>
           クリックしてファイルをアップロード
+          (最大3枚までとしてください) 
         </p>
         <%= f.file_field :images, name: 'item[images][]', id:"item-image" %>
       </div>
-      <div id="image-list" ></div>
+      <div id="image-list" >
        <% @item.images.each do |image| %>
         <%= image_tag image, class:"item-box-img" %>
        <% end %>
+      </div>
     </div>
     <%# /出品画像 %>
     <%# 商品名と商品説明 %>
@@ -142,7 +144,7 @@
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "出品する", class:"sell-btn" %>
+      <%= f.submit "出品する", class:"sell-btn", id:'btn1' %>
       <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>


### PR DESCRIPTION
# What
商品出品時のエラーの時のプレビュー画像削除

# Why
画像が壊れてしまっていたため

## Gyazo
* Gyazo GIF
出品が失敗すると、プレビュー画像が消えること：https://gyazo.com/eb1a4c9591cbd401b59545723b2d6263